### PR TITLE
fix: escape URLs and JSON for data attributes

### DIFF
--- a/views/assets/js/components/timer.js
+++ b/views/assets/js/components/timer.js
@@ -46,8 +46,8 @@ class Timer {
         xhr.onreadystatechange = () => {
           if (xhr.readyState === XMLHttpRequest.DONE) {
             if (xhr.status >= 200 && xhr.status < 300) {
-              let redirect = new URL(this.data.redirectUrl, location.origin);
-              const redirectParams = JSON.parse(decodeURIComponent(this.data.redirectParams));
+              const redirect = new URL(this.data.redirectUrl, location.origin);
+              const redirectParams = JSON.parse(this.data.redirectParams);
               for (const key in redirectParams) {
                 redirect.searchParams.append(key, redirectParams[key]);
               }
@@ -57,8 +57,8 @@ class Timer {
           }
         }
         ;
-        let formData = new FormData();
-        const deleteParams = JSON.parse(decodeURIComponent(this.data.deleteParams))
+        const formData = new FormData();
+        const deleteParams = JSON.parse(this.data.deleteParams)
         for (const [name, value] of Object.entries(deleteParams)) {
           formData.append(name, value);
         }

--- a/views/components/application/_timer.erb
+++ b/views/components/application/_timer.erb
@@ -1,12 +1,12 @@
 <div id="<%= comp.id %>"
      class="v-plugin v-timer"
-     data-plugin-callback='Timer'
+     data-plugin-callback="Timer"
      data-end-time="<%= comp.end_time %>"
      data-expired-message="<%= comp.expired_message %>"
-     data-redirect-url="<%= URI.decode_www_form(comp.redirect_url) %>"
-     data-redirect-params=<%= URI.decode_www_form(expand_hash(comp.redirect_params).to_json) %>
-     data-delete-url="<%= URI.decode_www_form(comp.delete_url) %>"
-     data-delete-params=<%= URI.decode_www_form(expand_hash(comp.delete_params).to_json) %>
+     data-redirect-url="<%= h comp.redirect_url %>"
+     data-redirect-params="<%= h comp.redirect_params.to_json %>"
+     data-delete-url="<%= h comp.delete_url %>"
+     data-delete-params="<%= h comp.delete_params.to_json %>"
      data-color="<%= comp.safe_color %>"
      data-warn-color="<%= comp.warn_color %>">
   <%= partial("components/icon", :locals => {comp: comp.icon, class_name: 'mdc-chip__icon mdc-chip__icon--leading' }) if comp.icon %>


### PR DESCRIPTION
Ensure user-provided URLs and query parameters are properly escaped
when rendering them into DOM data attribute values via the `h` ERB
helper method.